### PR TITLE
Add set of streams to filter out NOTE: Not tested with production data

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -16,7 +16,7 @@ import { SafeAppWeb3Modal } from "@gnosis.pm/safe-apps-web3modal";
 import "./App.css";
 import { Account, Contract, Faucet, GasGauge, Header, Ramp, ThemeSwitch } from "./components";
 import { INFURA_ID, NETWORK, NETWORKS } from "./constants";
-import { Transactor } from "./helpers";
+import { Transactor, filterStreamsThatAreHidden } from "./helpers";
 import { useContractConfig, useUserSigner } from "./hooks";
 import { Home, UserStream } from "./views";
 
@@ -206,9 +206,11 @@ function App(props) {
   // If you want to make 🔐 write transactions to your contracts, use the userSigner:
   const writeContracts = useContractLoader(userSigner, contractConfig);
 
-  const streams = useEventListener(readContracts, "StreamFactory", "StreamAdded", localProvider).map(s => {
-    return s.decode(s.data);
-  });
+  const rawStreams = useEventListener(readContracts, "StreamFactory", "StreamAdded", localProvider)
+  const streams = React.useMemo(() => rawStreams
+      .map(s => s.decode(s.data))
+      .filter(filterStreamsThatAreHidden),
+    [rawStreams]);
 
   // EXTERNAL CONTRACT EXAMPLE:
   //

--- a/packages/react-app/src/helpers/filterStreamsThatAreHidden.js
+++ b/packages/react-app/src/helpers/filterStreamsThatAreHidden.js
@@ -1,0 +1,13 @@
+const BlackListedStreams = new Set([
+  '0xA4c021089Ff1f8450dB7d49a8EF48AF030A513eD' // jklm.eth
+])
+
+/**
+ * Some addresses are not to be displayed on the front end
+ * so this adds the ability to filter them out
+ *
+ * Can be passed straight into .filter() on map of streams
+ *
+ * @param streamAddress
+ */
+export const filterStreamsThatAreHidden = (streamAddress) => BlackListedStreams.has(streamAddress)

--- a/packages/react-app/src/helpers/index.js
+++ b/packages/react-app/src/helpers/index.js
@@ -1,1 +1,2 @@
 export { default as Transactor } from "./Transactor";
+export * from './filterStreamsThatAreHidden'


### PR DESCRIPTION
Set can be easily updated to add new streams that we want to exclude.

Should be pretty efficient for when there are many streams but if the stream list / black list
are not likely to increase in size it could be overkill